### PR TITLE
Add .gitignore for python compiled files & pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Python Byte-compiled / optimized / DLL files
+**/__pycache__/
+**.py[cod]
+**$py.class


### PR DESCRIPTION
Would like to add a .gitignore file so that I don't have to manually remove the __pycache__ directory every time I commit when I'm using this submodule.